### PR TITLE
Core events dispatch work

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Installation
 
 You can `npm i @zambezi/grid` the component and can check the 'examples' folder for usage.
 
+Documentation
+-------------
+
+See [SUMMARY](SUMMARY.md) for detailed usage.
+
 Found an issue, or want to contribute?
 --------------------------------------
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,8 +5,7 @@ Summary
 
 
 - Basics
-
-  [row and cell events](man/row-and-cell-events.md)
+  - [Row and cell events](man/row-and-cell-events.md)
 
 ---
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,0 +1,14 @@
+Summary
+
+- [Introduction](README.md)
+- [How to contribute](CONTRIBUTING.md)
+
+
+- Basics
+
+  [row and cell events](man/row-and-cell-events.md)
+
+---
+
+- [Authors](AUTHORS.md)
+- [License](LICENSE.md)

--- a/examples/browser.html
+++ b/examples/browser.html
@@ -36,6 +36,7 @@
               }
             ]
           )
+          .on('cell-update', onCellUpdate)
     , rows = _.range(1, 2000).map(faker.Helpers.createCard)
 
   rows[10].locked = 'top'
@@ -47,6 +48,11 @@
       .style('height', '500px')
       .datum(rows)
       .call(table)
+
+  function onCellUpdate(cell, i) {
+    console.log('onCellUpdate', this, cell, i)
+    // console.debug('onCellUpdate', this, ...arguments)
+  }
 
 </script>
 </body>

--- a/examples/grid-core-events.html
+++ b/examples/grid-core-events.html
@@ -36,6 +36,13 @@
               }
             ]
           )
+          .on('cell-enter', handlerFor('cell-enter'))
+          .on('cell-exit', handlerFor('cell-exit'))
+          .on('cell-update', handlerFor('cell-update'))
+          .on('row-changed', handlerFor('row-changed'))
+          .on('row-enter', handlerFor('row-enter'))
+          .on('row-exit', handlerFor('row-exit'))
+          .on('row-update', handlerFor('row-update'))
 
     , rows = _.range(1, 2000).map(faker.Helpers.createCard)
 
@@ -48,6 +55,12 @@
       .style('height', '500px')
       .datum(rows)
       .call(table)
+
+  function handlerFor(type) {
+    return function handle() {
+      console.log(type, 'called on', this, 'with', arguments)
+    }
+  }
 
 </script>
 </body>

--- a/man/row-and-cell-events.md
+++ b/man/row-and-cell-events.md
@@ -15,7 +15,7 @@ A reference to the DOM element is available through the _this_ keyword.
 
 ```javascript
 const grid = createGrid()
-        .on("cell-update", onCellUpdate)
+        .on('cell-update', onCellUpdate)
     , threshold = 300
 
 select('.grid-target').datum(

--- a/man/row-and-cell-events.md
+++ b/man/row-and-cell-events.md
@@ -1,0 +1,53 @@
+## Row and cell life cycle events
+
+  The grid dispatches several events which can be used to extend its functionality.
+
+  Let's say you want to add a class to cells for which the value that it displays goes a certain threshold.
+  You can subscribe to the `cell-update` event.
+  This event will be dispatched for each cell as it is updated.
+  From the handler you can get a hold of the DOM element of the cell as well as the data bound to it.
+  You can use the data to determine if a class needs to be present on the node element and add it or remove it.
+
+  The function you provide as handler will receive the associated data as its argument.
+  The data element that you'll receive depends on the event that you're subscribed to; see the table below for more info.
+
+A reference to the DOM element is available through the _this_ keyword.
+
+```javascript
+const grid = createGrid()
+        .on("cell-update", onCellUpdate)
+    , threshold = 300
+
+select('.grid-target').datum(
+  {
+    { a: 100, b: 200 }
+  , { a: 550, b: 100 }
+  , { a: 350, b: 500 }
+  }
+).call(grid)
+
+function onCellUpdate(d, i) {
+  select(this)    // _this_ is the cell span
+      .classed(   // set the class if the value goes above the threshold
+        'is-over-threshold'
+      , d.value > threshold
+      )
+}
+```
+
+What follows is a list of the life cycle events dispatched by the grid.
+
+Event         | Dispatched                  | Object          | Notes
+--------------|-----------------------------|-----------------|------
+`row-enter`   | When a row is created       | Row Object(1)   | When virtualization is on, this will also be dispatched as rows are created when scrolling.
+`row-update`  | Every time the row updates  | Row Object      | This is also called when the row is created.
+`row-changed` | When the row changes        | Row Object      | If `rowChangedKey` is undefined, it will be dispatched the same as `row-update`. See performance section below.
+`row-exit`    | When a row is removed       | Row Object      | When virtualization is on, this will also be dispatched as rows are destroyed when scrolling.
+`cell-enter`  | When a cell is created      | Cell Object(2)  | When virtualization is on, this will also be dispatched as cells are created when scrolling.
+`cell-update` | Every time the cell updates | Cell Object     | This is also called when the cell is created.
+`cell-exit`   | When a cell is destroyed    | Cell Object     | When virtualization is on, this will also be dispatched as cells are destroyed when scrolling.
+
+(1) _Row Object_ is an array that holds the cell data for all the cells in a row
+The Row Object also provides references to the original row item in the list, to an array of the column specs for the cell block (cells in locked columns or blocks are in different cell blocks), and to the complete list of rows.
+
+(2) _Cell Object_ is an object which holds has reference to the row element, the column configuration object for that particular cell, as well as the column id and the property value associated with the cell.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "rollup-plugin-postcss": "0.1.1"
   },
   "dependencies": {
-    "@zambezi/d3-utils": "^3.1.0",
+    "@zambezi/d3-utils": "^3.2.0",
     "@zambezi/fun": "^2.0.1",
     "d3-array": "^1.0.1",
     "d3-dispatch": "^1.0.1",

--- a/src/body.js
+++ b/src/body.js
@@ -33,7 +33,16 @@ export function createBody() {
       , dispatch = createDispatch('visible-lines-change')
       , redispatcher = redispatch()
             .from(dispatch, 'visible-lines-change')
-            .from(cells, 'cell-update', 'cell-enter')
+            .from(
+              cells
+            , 'cell-enter'
+            , 'cell-exit'
+            , 'cell-update'
+            , 'row-changed'
+            , 'row-enter'
+            , 'row-exit'
+            , 'row-update'
+            )
             .create()
 
       , ensureSize = createEnsureSize()

--- a/src/body.js
+++ b/src/body.js
@@ -9,7 +9,7 @@ import { functor } from '@zambezi/fun'
 import { isUndefined, isEqual } from 'underscore'
 import { property } from '@zambezi/fun'
 import { select } from 'd3-selection'
-import { selectionChanged, rebind } from '@zambezi/d3-utils'
+import { selectionChanged, rebind, redispatch } from '@zambezi/d3-utils'
 
 import './body.css'
 
@@ -31,11 +31,16 @@ export function createBody() {
       , sheet = createGridSheet()
       , bodyBlockLayout = createBodyBlockLayout()
       , dispatch = createDispatch('visible-lines-change')
+      , redispatcher = redispatch()
+            .from(dispatch, 'visible-lines-change')
+            .from(cells, 'cell-update', 'cell-enter')
+            .create()
+
       , ensureSize = createEnsureSize()
       , api = rebind()
             .from(cells, 'rowChangedKey', 'rowKey')
             .from(bodyBlockLayout, 'virtualizeRows', 'virtualizeColumns')
-            .from(dispatch, 'on')
+            .from(redispatcher, 'on')
 
   let sizeValidationRound = 0
 

--- a/src/cells.js
+++ b/src/cells.js
@@ -72,12 +72,10 @@ export function createCells() {
         , columnComponentsAndNotifyUpdate = batch(
             runColumnComponents
           , forward(dispatcher, 'cell-update')
-          // , dispatcher['cell-update']
           )
         , columnClassAndNotifyEnter = batch(
             columnClass
           , forward(dispatcher, 'cell-enter')
-          // , dispatcher['cell-enter']
           )
 
         , rows = list.selectAll('.zambezi-grid-row')
@@ -85,29 +83,29 @@ export function createCells() {
 
         , rowsExit = rows.exit()
               .remove()
-              // .each(dispatcher['row-exit'])
+              .each(forward(dispatcher, 'row-exit'))
 
         , rowsEnter = rows.enter()
             .select(appendRow)
-              // .each(dispatcher['row-enter'])
+              .each(forward(dispatcher, 'row-enter'))
 
         , rowChanged = rows
             .merge(rowsEnter)
-              // .each(dispatcher['row-update'])
+              .each(forward(dispatcher, 'row-update'))
             .select(
               changed.key(
                 orderAndKey(rowChangedKey, visibleCellsHash)
               )
             )
               .each(updateRow)
-              // .each(dispatcher['row-changed'])
+              .each(forward(dispatcher, 'row-changed'))
 
         , cellsUpdate = rowChanged.selectAll('.zambezi-grid-cell')
             .data(d => d, id)
 
         , cellsExit = cellsUpdate.exit()
               .remove()
-              // .each(dispatcher['cell-exit'])
+              .each(forward(dispatcher, 'cell-exit'))
 
         , cellsEnter = cellsUpdate.enter()
             .select(append)
@@ -117,7 +115,6 @@ export function createCells() {
 
     cellsMerged.select(firstLastChanged).each(updateFirstLast)
     cellsMerged.each(columnComponentsAndNotifyUpdate)
-          //.each(function() { console.debug('each', this, ...arguments)})
   }
 
   function updateFirstLast() {

--- a/src/grid.js
+++ b/src/grid.js
@@ -62,8 +62,13 @@ export function createGrid() {
             .from(
               body
             , 'visible-lines-change'
-            , 'cell-update'
             , 'cell-enter'
+            , 'cell-exit'
+            , 'cell-update'
+            , 'row-changed'
+            , 'row-enter'
+            , 'row-exit'
+            , 'row-update'
             )
             .create()
 

--- a/src/grid.js
+++ b/src/grid.js
@@ -59,7 +59,12 @@ export function createGrid() {
 
       , redispatcher = redispatch()
             .from(dispatchDraw, 'draw')
-            .from(body, 'visible-lines-change')
+            .from(
+              body
+            , 'visible-lines-change'
+            , 'cell-update'
+            , 'cell-enter'
+            )
             .create()
 
       , api = rebind()


### PR DESCRIPTION
## Description

In this PR are implemented the dispatch of the core events of the grid, which can be used as extension points by grid clients.

More detailed info on what these events are can be found on the proposed [doc update](https://github.com/zambezi/grid/blob/core-events-dispatch-work/man/row-and-cell-events.md)

## Motivation and Context

This is the frist part of adding extension points to the grid -- so as not to have to bloat the core implementation with features, but let extra functionality to be added externally.

## How Was This Tested?

A new rig has been added to the `examples` folder in which these events are showcased.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
