### PR TITLE
Skip redraw when hidden

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rollup-plugin-postcss": "0.1.1"
   },
   "dependencies": {
-    "@zambezi/d3-utils": "^3.2.0",
+    "@zambezi/d3-utils": "^3.3.0-skip-when-hidden.0",
     "@zambezi/fun": "^2.0.1",
     "d3-array": "^1.0.1",
     "d3-dispatch": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rollup-plugin-postcss": "0.1.1"
   },
   "dependencies": {
-    "@zambezi/d3-utils": "^3.3.0-skip-when-hidden.0",
+    "@zambezi/d3-utils": "^3.3.0",
     "@zambezi/fun": "^2.0.1",
     "d3-array": "^1.0.1",
     "d3-dispatch": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zambezi/grid",
-  "version": "0.7.0",
+  "version": "0.8.0-skip-when-hidden.0",
   "description": "D3 component for drawing financial grids.",
   "keywords": [
     "d3",

--- a/src/grid.js
+++ b/src/grid.js
@@ -21,7 +21,7 @@ import { createUnpackNestedRows } from './unpack-nested-rows'
 import { dispatch as createDispatch } from 'd3-dispatch'
 import { ensureData } from './ensure-data'
 import { ensureId } from './ensure-id'
-import { rebind, redispatch, call, each, redraw, createResize, createAutoDirty, throttle, throttleToAnimationFrame } from '@zambezi/d3-utils'
+import { rebind, redispatch, call, skipWhenHidden, each, redraw, createResize, createAutoDirty, throttle, throttleToAnimationFrame } from '@zambezi/d3-utils'
 
 import './grid.css'
 
@@ -97,5 +97,5 @@ export function createGrid() {
         , each(ensureId)
         )
 
-  return api(autodirty(redraw(throttle(throttleToAnimationFrame(grid), 10))))
+  return api(autodirty(redraw(throttle(throttleToAnimationFrame(skipWhenHidden(grid)), 10))))
 }


### PR DESCRIPTION
## Description

This PR installs the [skip when hidden](https://github.com/zambezi/d3-utils/blob/master/man/skip-when-hidden.md) D3 util on the grid to prevent attempts at redrawing when the grid is on a `display: none` node.

## Motivation and Context

The grid cannot render properly if it's detached -- currently it will fail with an `Illegal Size` error.
But it is not uncommon for clients to try to render the grid onto hidden divs; the most usual case begin a grid on an inactive "tab".

With this PR the grid will just not try to render if it determines that it's not visible./

## How Was This Tested?

On a local rig on a "tabbing" application.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
