### PR TITLE
Fix accessing of d3 via global object.

### DIFF
--- a/src/nested-row-expanders.js
+++ b/src/nested-row-expanders.js
@@ -19,7 +19,7 @@ export function createNestedRowExpanders() {
 
   function nestedRowExpanders(d, i) {
 
-    const cell = d3.select(this).classed('nested-expander-cell', true)
+    const cell = select(this).classed('nested-expander-cell', true)
         , column = d.column
         , value = d.value
         , row = d.row


### PR DESCRIPTION
This script was using `d3.select` (which then had to be globally defined, via `window.d3`) instead of the version of the function already imported directly via `import { select, event } from 'd3-selection'`.