### PR TITLE
Implement mouse wheel on the grid body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 Makefile
 *.log
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zambezi/grid",
-  "version": "0.9.0",
+  "version": "0.10.0-mouse-wheel.1",
   "description": "D3 component for drawing financial grids.",
   "keywords": [
     "d3",

--- a/src/grid.js
+++ b/src/grid.js
@@ -10,6 +10,7 @@ import { createHeaders } from './headers'
 import { createLayOutBodyAndOverlays } from './lay-out-body-and-overlays'
 import { createMarkRowIndices } from './mark-row-indices'
 import { createMeasureGridArea }  from './measure-grid-area'
+import { createMouseWheel } from './mouse-wheel'
 import { createProcessRowData } from './process-row-data'
 import { createProcessSizeAndClipping } from './process-size-and-clipping'
 import { createRunExternalComponents } from './run-external-components'
@@ -85,6 +86,7 @@ export function createGrid() {
         , call(createHeaders())
         , call(body)
         , each(createLayOutBodyAndOverlays())
+        , call(createMouseWheel())
         , call(processSizeAndClipping)
         , call(createMeasureGridArea())
         , call(createMarkRowIndices())

--- a/src/mouse-wheel.js
+++ b/src/mouse-wheel.js
@@ -55,8 +55,3 @@ function discoverWheelEventType() {
   : 'DOMMouseScroll'                                            // default (old Firefox)
   )
 }
-
-
-
-
-

--- a/src/mouse-wheel.js
+++ b/src/mouse-wheel.js
@@ -1,3 +1,8 @@
+import { select, event } from 'd3-selection'
+
+const wheelDeltaMode = { pixel: 0, line: 1, page: 2 }
+    , wheelEventType = discoverWheelEventType()
+
 export function createMouseWheel() {
   function mouseWheel(s) {
     s.each(mouseWheelEach)
@@ -6,6 +11,52 @@ export function createMouseWheel() {
   return mouseWheel
 
   function mouseWheelEach(d, i) {
-    console.log('mouseWheelEach', d, this)
+    const target = select(this)
+            .select('.zambezi-grid-body')
+              .on(wheelEventType, onWheel)
+
+    function onWheel() {
+      const freeRows = d.rows.free
+          , actualHeight = freeRows.actualHeight
+          , measuredHeight = freeRows.measuredHeight
+          , minScroll = 0
+          , maxScroll = measuredHeight - actualHeight
+          , scroll = Math.max(
+              minScroll
+            , Math.min(
+                d.scroll.top - wheelDelta()
+              , maxScroll
+              )
+            )
+          , isInternalGridScroll = scroll > minScroll && scroll < maxScroll
+          , scrollEvent = { top: scroll , left: d.scroll.left }
+
+      if (isInternalGridScroll) event.preventDefault()
+
+      target.dispatch('grid-scroll',  { bubbles: true, detail: scrollEvent })
+          .dispatch('redraw',  { bubbles: true })
+
+      function wheelDelta() {
+        return (
+          event.deltaY * (event.deltaMode === wheelDeltaMode.line ? -40 : -1)
+          ||  event.wheelDeltaY
+          ||  event.wheelDelta
+          ||  0
+        )
+      }
+    }
   }
 }
+
+function discoverWheelEventType() {
+  return (
+    'onwheel' in document.createElement('div')  ? 'wheel'       // Modern browsers
+  : document.onmousewheel !== undefined         ? 'mousewheel'  // Webkit and IE
+  : 'DOMMouseScroll'                                            // default (old Firefox)
+  )
+}
+
+
+
+
+

--- a/src/mouse-wheel.js
+++ b/src/mouse-wheel.js
@@ -1,0 +1,11 @@
+export function createMouseWheel() {
+  function mouseWheel(s) {
+    s.each(mouseWheelEach)
+  }
+
+  return mouseWheel
+
+  function mouseWheelEach(d, i) {
+    console.log('mouseWheelEach', d, this)
+  }
+}

--- a/src/process-size-and-clipping.js
+++ b/src/process-size-and-clipping.js
@@ -1,4 +1,4 @@
-import { fromDetail, fromTarget } from '@zambezi/d3-utils'
+import { fromDetail } from '@zambezi/d3-utils'
 import { isIE } from './is-ie'
 import { isNumber, clone } from 'underscore'
 import { select } from 'd3-selection'
@@ -35,7 +35,7 @@ export function createProcessSizeAndClipping() {
 
     if (!rowHeight) rowHeight = produceRowHeight()
 
-    root.on('grid-scroll.size-and-clipping', fromTarget(onGridScroll))
+    root.on('grid-scroll.size-and-clipping', fromDetail(onGridScroll))
 
     measureBlocks()
     calculateVerticalClipping()

--- a/src/scrollers.js
+++ b/src/scrollers.js
@@ -95,8 +95,7 @@ export function createScrollers() {
           , left = horizontal.property('scrollLeft')
 
       select(this)
-          .datum({ top, left })
-          .dispatch('grid-scroll', { bubbles: true })
+          .dispatch('grid-scroll', { bubbles: true, detail: { top, left } })
           .dispatch('redraw', { bubbles: true })
     }
 


### PR DESCRIPTION
## Description
Set an handler on the grid body to scroll the grid with the mouse wheel.

## Motivation and Context
We need to handle scrolling programmatically because the scrollers in the grid are not browser native (because of virtualised rows).

## How Was This Tested?
Manually [on this block](https://bl.ocks.org/gabrielmontagne/61bf45ef534990696005d88bfcabb164)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
