### PR TITLE
Implement pinned nested rows

### DIFF
--- a/examples/pinned-nested-rows.html
+++ b/examples/pinned-nested-rows.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<head><meta charset="utf-8" /></head>
+<body>
+<h2>grid example</h2>
+<div class="grid-target"></div>
+<link rel="stylesheet" type="text/css" href="../node_modules/normalize.css/normalize.css">
+<script src="../node_modules/underscore/underscore.js"></script>
+<script src="../node_modules/faker/faker.js"></script>
+<script src="../node_modules/@zambezi/fun/dist/fun.js"></script>
+<script src="../node_modules/d3/build/d3.js"></script>
+<script src="../node_modules/@zambezi/d3-utils/dist/d3-utils.js"></script>
+<script src="../dist/grid.js"></script>
+<script>
+  var table = grid.createGrid()
+        .columns(
+          [
+            { key: 'pinned', width: 70 }
+          , {
+              components: [
+                grid.createNestedRowExpanders()
+              ]
+            , key: 'label'
+            , label: 'expanders'
+            , width: 100
+            , resizable: false
+            , draggable: false
+            }
+          , { key: 'label', sortDescending: true }
+          , { key: 'nestLevel', width: 70, sortable: false }
+          ]
+        )
+        .showPinnedRows(true)
+    , rows = [
+        { label: 'A' }
+      , {
+          label: 'B'
+        , expanded: true
+        , children: [
+            { label: 'B0' }
+          , { label: 'B1', pinned: true }
+          , {
+              label: 'B2'     // not expanded, therfore not shown.
+            , children: [
+                { label: 'B2a' }
+              , { label: 'B2b' }
+              , {
+                  label: 'B2c'
+                , children: [
+                    { label: 'B2c0' }
+                  , {
+                      label: 'B2c1'
+                    , children: [
+                        { label: 'B2c1A' }
+                      , { label: 'B2c1B' }
+                      , { label: 'B2c1C' }
+                      , { label: 'B2c1D' }
+                      ]
+                    }
+                  , { label: 'B2c2' }
+                  , { label: 'B2c3' }
+                  ]
+                }
+              , { label: 'B2d' }
+              ]
+            }
+          , {
+              label: 'B3'
+            , expanded: true
+            , children: [
+                { label: 'B3a' }
+              , { label: 'B3b' }
+              , { label: 'B3c' }
+              , { label: 'B3d', pinned: true }
+              ]
+            }
+          ]
+        }
+      , { label: 'C' }
+      , { label: 'D' }
+      ]
+
+  d3.select('.grid-target')
+      .style('height', '500px')
+      .datum(rows)
+      .call(table)
+
+</script>
+</body>

--- a/man/nested-rows.md
+++ b/man/nested-rows.md
@@ -49,3 +49,32 @@ The grid supports arbitrarily nested rows.
 Nested columns can have their own `children` columns with deeper nested rows.
 
 NOTE: cells that use the nested rows expanded components don't support truncation.
+
+
+## Nested pinned rows
+
+The grid component supports nested pinned row at the first-level depth.
+This means that pinned rows (ie rows with the `pinned` property) will be shown even if the parent is not expanded.
+Although, if the parent is in turn a child of a collapsed parent, they will not be shown.
+
+`showPinnedRows` is turned off by default on the grid because it comes at a small computational cost, but can be explicitly turned on if needed:
+
+```javascript
+...
+import { createNestedRowExpanders, createGrid } from '@zambezi/grid'
+
+const grid = createGrid()
+          .columns(
+            [
+              ...
+            , {
+                key: 'client-name'
+              , components: [ createNestedRowExpanders() ]
+              , width: 170
+              }
+            ]
+          )
+          .showPinnedRows(true)
+```
+
+You can see an example of this in `examples\pinned-nested-rows.html`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zambezi/grid",
-  "version": "0.10.0",
+  "version": "0.11.0-nested-pinned-row.2",
   "description": "D3 component for drawing financial grids.",
   "keywords": [
     "d3",

--- a/src/grid.js
+++ b/src/grid.js
@@ -35,6 +35,7 @@ export function createGrid() {
       , processSizeAndClipping = createProcessSizeAndClipping()
       , columnDrag = createColumnDrag()
       , resize = createResize()
+      , unpackNestedRows = createUnpackNestedRows()
       , columnSizers = createColumnSizers()
       , dispatchDraw = createDispatch('draw')
       , groupRows = createGroupRows()
@@ -75,6 +76,7 @@ export function createGrid() {
             .from(serverSideFilterAndSort, 'serverSideFilterAndSort')
             .from(setupTemplate, 'template')
             .from(sortRowHeaders, 'sortableByDefault')
+            .from(unpackNestedRows, 'showPinnedRows')
 
       , grid = compose(
           call(() => dispatchDraw.call('draw'))
@@ -90,7 +92,7 @@ export function createGrid() {
         , call(processSizeAndClipping)
         , call(createMeasureGridArea())
         , call(createMarkRowIndices())
-        , call(createUnpackNestedRows())
+        , call(unpackNestedRows)
         , call(createSortRows())
         , call(processRowData)
         , call(runExternalComponentsPre)

--- a/src/unpack-nested-rows.js
+++ b/src/unpack-nested-rows.js
@@ -10,15 +10,15 @@ export function createUnpackNestedRows() {
 
   let cache = null
     , filters = null
-    , findPinnedRows = true
+    , showPinnedRows = false
 
   function unpackNestedRows(s) {
     s.each(unpackNestedRowsEach)
   }
 
-  unpackNestedRows.findPinnedRows = function(value) {
-    if (!arguments.length) return findPinnedRows
-    findPinnedRows = value
+  unpackNestedRows.showPinnedRows = function(value) {
+    if (!arguments.length) return showPinnedRows
+    showPinnedRows = value
     return unpackNestedRows
   }
 
@@ -77,7 +77,7 @@ export function createUnpackNestedRows() {
           hasNestedRows = true
         }
 
-        if (row.expanded || findPinnedRows) {
+        if (row.expanded || showPinnedRows) {
           children
               .map(wrap)
               .filter(filterChild)
@@ -85,7 +85,7 @@ export function createUnpackNestedRows() {
               .reduce(unpackNestedRowsForLevel(level + 1), acc)
 
           function filterChild(childRow) {
-            if (!row.expanded && findPinnedRows && !childRow.pinned) return false
+            if (!row.expanded && showPinnedRows && !childRow.pinned) return false
             childRow.parentRow = row
             return filters.every(runFilter.bind(null, childRow, i, a))
           }


### PR DESCRIPTION
## Description
Allow a nested row to be pinned, i.e. shown if the parent is collapsed. This behavior is configurable on the grid and will work only at depth 1 (see man page below)

## Motivation and Context
It's useful to have the possibility of pinning a row even when the parent is collapsed. This is simple, so it's a quick win.

## How Was This Tested?
Manually, see [this block](https://bl.ocks.org/gabrielmontagne/964ca47e4e2dcda3717ea7ceae03ca5b)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
