### PR TITLE
Simple nested expanders

### DIFF
--- a/examples/simple-nested-rows.html
+++ b/examples/simple-nested-rows.html
@@ -44,7 +44,7 @@
             { label: 'B0' }
           , { label: 'B1' }
           , {
-              label: 'B2'     // not expanded, therfore not shown.
+              label: 'B2'     // not expanded, therefore not shown.
             , children: [
                 { label: 'B2a' }
               , { label: 'B2b' }

--- a/examples/simple-nested-rows.html
+++ b/examples/simple-nested-rows.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<head><meta charset="utf-8" /></head>
+<body>
+<h2>grid example</h2>
+<div class="grid-target"></div>
+<link rel="stylesheet" type="text/css" href="../node_modules/normalize.css/normalize.css">
+<script src="../node_modules/underscore/underscore.js"></script>
+<script src="../node_modules/faker/faker.js"></script>
+<script src="../node_modules/@zambezi/fun/dist/fun.js"></script>
+<script src="../node_modules/d3/build/d3.js"></script>
+<script src="../node_modules/@zambezi/d3-utils/dist/d3-utils.js"></script>
+<script src="../dist/grid.js"></script>
+<script>
+  var table = grid.createGrid()
+        .columns(
+          [
+            {
+              components: [
+                grid.createNestedRowExpanders()
+              ]
+            , key: 'label'
+            , label: 'expanders'
+            , width: 100
+            , resizable: false
+            , draggable: false
+            }
+          , {
+              components: [
+                grid.createSimpleNestedRowExpanders()
+              ]
+            , label: 'X'
+            , width: 30
+            }
+          , { key: 'label', sortDescending: true }
+          , { key: 'nestLevel', width: 70, sortable: false }
+          ]
+        )
+    , rows = [
+        { label: 'A' }
+      , {
+          label: 'B'
+        , expanded: true
+        , children: [
+            { label: 'B0' }
+          , { label: 'B1' }
+          , {
+              label: 'B2'     // not expanded, therfore not shown.
+            , children: [
+                { label: 'B2a' }
+              , { label: 'B2b' }
+              , {
+                  label: 'B2c'
+                , children: [
+                    { label: 'B2c0' }
+                  , {
+                      label: 'B2c1'
+                    , children: [
+                        { label: 'B2c1A' }
+                      , { label: 'B2c1B' }
+                      , { label: 'B2c1C' }
+                      , { label: 'B2c1D' }
+                      ]
+                    }
+                  , { label: 'B2c2' }
+                  , { label: 'B2c3' }
+                  ]
+                }
+              , { label: 'B2d' }
+              ]
+            }
+          , {
+              label: 'B3'
+            , expanded: true
+            , children: [
+                { label: 'B3a' }
+              , { label: 'B3b' }
+              , { label: 'B3c' }
+              , { label: 'B3d' }
+              ]
+            }
+          ]
+        }
+      , { label: 'C' }
+      , { label: 'D' }
+      ]
+
+  d3.select('.grid-target')
+      .style('height', '500px')
+      .datum(rows)
+      .call(table)
+
+</script>
+</body>

--- a/examples/simple-nested-rows.html
+++ b/examples/simple-nested-rows.html
@@ -29,7 +29,7 @@
                 grid.createSimpleNestedRowExpanders()
               ]
             , label: 'X'
-            , width: 30
+            , width: 40
             }
           , { key: 'label', sortDescending: true }
           , { key: 'nestLevel', width: 70, sortable: false }

--- a/man/nested-rows.md
+++ b/man/nested-rows.md
@@ -20,6 +20,8 @@ const data = [
 d3.select('.grid').datum(data).call(grid)
 ```
 
+### Nested row expanders
+
 In order to display the row hierarchy on a particular column you need to use the _nested row expanders_ column component.
 Simply import it and add it to the `components` list for the column you want it to operate on.
 
@@ -50,6 +52,29 @@ Nested columns can have their own `children` columns with deeper nested rows.
 
 NOTE: cells that use the nested rows expanded components don't support truncation.
 
+### Simple row expanders
+
+If you don't need tree-like expanders that are deeply nested, you can use `simpleNestedRowExpanders` to render a basic expand/collapse control.
+Their usage is similar to the nested row expanders:
+
+```javascript
+...
+import { createNestedRowExpanders, createGrid } from '@zambezi/grid'
+
+const grid = createGrid()
+          .columns(
+            [
+              ...
+            , {
+                key: 'client-name'
+              , components: [ createSimpleNestedRowExpanders() ]
+              , width: 40
+              }
+            ]
+          )
+```
+
+(See the simple-nested-row example in the examples folder for a working sample)
 
 ## Nested pinned rows
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 export { createGrid } from './grid'
 export { createNestedRowExpanders } from './nested-row-expanders'
+export { createSimpleNestedRowExpanders } from './simple-nested-row-expanders'
 export { formatRollup, formatNonRollup } from './group-rows'
 export { unwrap } from './unwrap-row'
 export { updateTextIfChanged } from './update-text-if-changed'

--- a/src/simple-nested-row-expanders.css
+++ b/src/simple-nested-row-expanders.css
@@ -1,0 +1,19 @@
+.zambezi-grid-cell.simple-nested-expander-cell {
+  font-size: 16px;
+  font-family: monospace;
+  white-space: pre;
+  color: #555;
+}
+
+.zambezi-grid-cell.simple-nested-expander-cell.is-collapse:hover,
+.zambezi-grid-cell.simple-nested-expander-cell.is-expand:hover {
+  color: black;
+}
+
+.zambezi-grid-cell.simple-nested-expander-cell.is-expand:after {
+  content: '➖';
+}
+
+.zambezi-grid-cell.simple-nested-expander-cell.is-collapse:after {
+  content: '➕';
+}

--- a/src/simple-nested-row-expanders.js
+++ b/src/simple-nested-row-expanders.js
@@ -1,7 +1,19 @@
+import './simple-nested-row-expanders.css'
+import { select } from 'd3-selection'
+
 export function createSimpleNestedRowExpanders() {
 
   function simpleNestedRowExpanders(d) {
     console.log('Called on', this, d)
+
+    const row = d.row
+        , hasNested = !!(row.children && row.children.length)
+        , isExpand = hasNested && row.expanded
+        , isCollapse = hasNested && !isExpand
+
+    select(this).classed('simple-nested-expander-cell', true)
+        .classed('is-expand', isExpand)
+        .classed('is-collapse', isCollapse)
   }
 
   return simpleNestedRowExpanders

--- a/src/simple-nested-row-expanders.js
+++ b/src/simple-nested-row-expanders.js
@@ -1,8 +1,10 @@
 import './simple-nested-row-expanders.css'
 import { select } from 'd3-selection'
+import { selectionChanged } from '@zambezi/d3-utils'
 import { unwrap } from './unwrap-row'
 
 export function createSimpleNestedRowExpanders() {
+  const changed = selectionChanged()
 
   function simpleNestedRowExpanders(d) {
     const row = d.row
@@ -10,7 +12,9 @@ export function createSimpleNestedRowExpanders() {
         , isExpand = hasNested && row.expanded
         , isCollapse = hasNested && !isExpand
 
-    select(this).classed('simple-nested-expander-cell', true)
+    select(this)
+      .select(changed.key(d => `${hasNested}|${isExpand}|${isCollapse}`))
+        .classed('simple-nested-expander-cell', true)
         .classed('is-expand', isExpand)
         .classed('is-collapse', isCollapse)
         .on('click.simple-expander-toggle',

--- a/src/simple-nested-row-expanders.js
+++ b/src/simple-nested-row-expanders.js
@@ -1,11 +1,10 @@
 import './simple-nested-row-expanders.css'
 import { select } from 'd3-selection'
+import { unwrap } from './unwrap-row'
 
 export function createSimpleNestedRowExpanders() {
 
   function simpleNestedRowExpanders(d) {
-    console.log('Called on', this, d)
-
     const row = d.row
         , hasNested = !!(row.children && row.children.length)
         , isExpand = hasNested && row.expanded
@@ -14,6 +13,28 @@ export function createSimpleNestedRowExpanders() {
     select(this).classed('simple-nested-expander-cell', true)
         .classed('is-expand', isExpand)
         .classed('is-collapse', isCollapse)
+        .on('click.simple-expander-toggle',
+          isExpand   ? collapse
+        : isCollapse ? expand
+        : null
+        )
+        .on('click.simple-expander-redraw', hasNested ? redraw : null)
+
+    function expand(d) {
+      unwrap(d.row).expanded = true
+    }
+
+    function collapse(d) {
+      unwrap(d.row).expanded = false
+    }
+
+    function redraw() {
+      event.stopImmediatePropagation()
+
+      select(this)
+        .dispatch('data-dirty', { bubbles: true })
+        .dispatch('redraw', { bubbles: true })
+    }
   }
 
   return simpleNestedRowExpanders

--- a/src/simple-nested-row-expanders.js
+++ b/src/simple-nested-row-expanders.js
@@ -1,0 +1,8 @@
+export function createSimpleNestedRowExpanders() {
+
+  function simpleNestedRowExpanders(d) {
+    console.log('Called on', this, d)
+  }
+
+  return simpleNestedRowExpanders
+}


### PR DESCRIPTION
## Description
A simpler interface for non-deeply nested row expanders

## Motivation and Context
This takes out the complexity of the full-fledged expanders, which are not needed in many of the use cases, 

## How Was This Tested?
Manually, see [this block](http://bl.ocks.org/gabrielmontagne/c8b5243a498e5a1e0a4d17482eff844b)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
