### PR TITLE
Expand the "pinned row" concept to use a predicate instead of a property

### DIFF
--- a/examples/pinned-nested-rows.html
+++ b/examples/pinned-nested-rows.html
@@ -29,7 +29,7 @@
           , { key: 'nestLevel', width: 70, sortable: false }
           ]
         )
-        .showPinnedRows(true)
+        .showRowWhenCollapsed(d => d.pinned)
     , rows = [
         { label: 'A' }
       , {

--- a/man/nested-rows.md
+++ b/man/nested-rows.md
@@ -51,13 +51,13 @@ Nested columns can have their own `children` columns with deeper nested rows.
 NOTE: cells that use the nested rows expanded components don't support truncation.
 
 
-## Nested pinned rows
+## Show rows when collapsed
 
-The grid component supports nested pinned row at the first-level depth.
-This means that pinned rows (ie rows with the `pinned` property) will be shown even if the parent is not expanded.
+The grid component supports optionally showing nested row base on a predicate, at the first-level depth.
+This means that conditionally always-shown rows (ie rows that return `true` from the `showRowWhenCollapsed` predicate) will be shown even if the parent is not expanded.
 Although, if the parent is in turn a child of a collapsed parent, they will not be shown.
 
-`showPinnedRows` is turned off by default on the grid because it comes at a small computational cost, but can be explicitly turned on if needed:
+`showRowWhenCollapsed` is `null` by default, so all rows will be hidden when the parent row is collapsed. It is possible to specify it like this:
 
 ```javascript
 ...
@@ -74,7 +74,7 @@ const grid = createGrid()
               }
             ]
           )
-          .showPinnedRows(true)
+          .showRowWhenCollapsed(d => d.pinned) // If row has a truthy `pinned` property, show it anyways
 ```
 
 You can see an example of this in `examples\pinned-nested-rows.html`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zambezi/grid",
-  "version": "0.11.0",
+  "version": "0.12.0-pinned-predicate-work.1",
   "description": "D3 component for drawing financial grids.",
   "keywords": [
     "d3",

--- a/src/grid.js
+++ b/src/grid.js
@@ -76,7 +76,7 @@ export function createGrid() {
             .from(serverSideFilterAndSort, 'serverSideFilterAndSort')
             .from(setupTemplate, 'template')
             .from(sortRowHeaders, 'sortableByDefault')
-            .from(unpackNestedRows, 'showPinnedRows')
+            .from(unpackNestedRows, 'showRowWhenCollapsed')
 
       , grid = compose(
           call(() => dispatchDraw.call('draw'))

--- a/src/unpack-nested-rows.js
+++ b/src/unpack-nested-rows.js
@@ -1,6 +1,7 @@
 import { property } from '@zambezi/fun'
 import { select } from 'd3-selection'
 import { selectionChanged } from '@zambezi/d3-utils'
+import { isFunction } from 'underscore'
 import { wrap } from './wrap-row'
 
 const rowNestedLevelChanged = selectionChanged()
@@ -10,15 +11,15 @@ export function createUnpackNestedRows() {
 
   let cache = null
     , filters = null
-    , showPinnedRows = false
+    , showRowWhenCollapsed = null
 
   function unpackNestedRows(s) {
     s.each(unpackNestedRowsEach)
   }
 
-  unpackNestedRows.showPinnedRows = function(value) {
-    if (!arguments.length) return showPinnedRows
-    showPinnedRows = value
+  unpackNestedRows.showRowWhenCollapsed = function(value) {
+    if (!arguments.length) return showRowWhenCollapsed
+    showRowWhenCollapsed = value
     return unpackNestedRows
   }
 
@@ -77,7 +78,7 @@ export function createUnpackNestedRows() {
           hasNestedRows = true
         }
 
-        if (row.expanded || showPinnedRows) {
+        if (row.expanded || showRowWhenCollapsed) {
           children
               .map(wrap)
               .filter(filterChild)
@@ -85,7 +86,7 @@ export function createUnpackNestedRows() {
               .reduce(unpackNestedRowsForLevel(level + 1), acc)
 
           function filterChild(childRow) {
-            if (!row.expanded && showPinnedRows && !childRow.pinned) return false
+            if (!row.expanded && isFunction(showRowWhenCollapsed) && !showRowWhenCollapsed(childRow)) return false
             childRow.parentRow = row
             return filters.every(runFilter.bind(null, childRow, i, a))
           }


### PR DESCRIPTION
## Description
Allow predicates instead of `pinned` property.

## Motivation and Context
In order to make the grid more configurable, we expanded the concept of "pinned row" to use a predicate that says if the row is always shown, even when the parent is collapsed or not. This is built on top of #18 and it will behave the same (i.e. it will support one level of depth)

## How Was This Tested?
Manually, see this [updated gist](https://bl.ocks.org/gabrielmontagne/964ca47e4e2dcda3717ea7ceae03ca5b).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
