### PR TITLE
Expose row changed key optimization hook

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -13,6 +13,7 @@ Summary
   - [Nested rows](man/nested-rows.md)
   - [Grouped rows](man/grouped-rows.md)
   - [Server side filter and sorting](man/server-side-filter-and-sort.md)
+  - [Grid performance and row constancy](man/grid-performance-and-row-constancy.md)
 
 ---
 

--- a/examples/update-optimization-with-row-changed-key.html
+++ b/examples/update-optimization-with-row-changed-key.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<head><meta charset="utf-8" /></head>
+<body>
+<h2>grid example</h2>
+<button id="start-updates">Start updates</button>
+<button id="stop-updates">Stop updates</button>
+<div class="grid-target"></div>
+<link rel="stylesheet" type="text/css" href="../node_modules/normalize.css/normalize.css">
+<script src="../node_modules/underscore/underscore.js"></script>
+<script src="../node_modules/faker/faker.js"></script>
+<script src="../node_modules/@zambezi/fun/dist/fun.js"></script>
+<script src="../node_modules/d3/build/d3.js"></script>
+<script src="../node_modules/@zambezi/d3-utils/dist/d3-utils.js"></script>
+<script src="../dist/grid.js"></script>
+<script>
+  const rows = _.shuffle(
+          _.range(1, 1000)
+              .map(_.compose(_.partial(_.pick, _, 'name', 'username', 'email'), faker.Helpers.createCard))
+              .map(function(row, i) { row.id = 'row' + i; return row }))
+
+      , table = grid.createGrid()
+            .rowKey(d => d.id)
+            .rowChangedKey(d => d.username)
+            .on('row-changed', () => ++changes)
+            .on('draw.log', () => (console.log(`${changes} row changes per draw`), changes = 0))
+
+      , target = d3.select('.grid-target')
+            .style('height', '500px')
+            .datum(rows)
+            .call(table)
+
+  let changes = 0
+
+  d3.select('#start-updates')
+    .on('click', startUpdates)
+
+  d3.select('#stop-updates')
+    .on('click', stopUpdates)
+
+  var updates
+
+  function stopUpdates() {
+    updates && updates.forEach(clearInterval)
+  }
+
+  function startUpdates() {
+    updates = rows.map(function(n, i) {
+      var id = 'row' + i
+
+      return setInterval(function() {
+        rows.some(function(row) {
+          if (row.id === id) {
+            row.username = Math.random().toString(16)
+            target.call(table)
+            return true
+          }
+        })
+      }, 1000 + Math.floor(Math.random() * 100))
+    })
+  }
+</script>
+</body>

--- a/examples/update-optimization-with-row-changed-key.html
+++ b/examples/update-optimization-with-row-changed-key.html
@@ -2,9 +2,17 @@
 <head><meta charset="utf-8" /></head>
 <body>
 <h2>grid example</h2>
-<button id="start-updates">Start updates</button>
-<button id="stop-updates">Stop updates</button>
+<p>
+  <button id="start-updates">Start updates</button>
+  <button id="stop-updates">Stop updates</button>
+</p>
+<p>
+  <input type="checkbox" id="use-optimization">Use "row changed key" optimization</input>
+</p>
+
+<p>Row changes on last grid redraw: <strong id="counter"></strong> </p>
 <div class="grid-target"></div>
+
 <link rel="stylesheet" type="text/css" href="../node_modules/normalize.css/normalize.css">
 <script src="../node_modules/underscore/underscore.js"></script>
 <script src="../node_modules/faker/faker.js"></script>
@@ -18,11 +26,11 @@
               .map(_.compose(_.partial(_.pick, _, 'name', 'username', 'email'), faker.Helpers.createCard))
               .map(function(row, i) { row.id = 'row' + i; return row }))
 
+      , counter = d3.select('#counter')
       , table = grid.createGrid()
             .rowKey(d => d.id)
-            .rowChangedKey(d => d.username)
             .on('row-changed', () => ++changes)
-            .on('draw.log', () => (console.log(`${changes} row changes per draw`), changes = 0))
+            .on('draw.log', () => (counter.text(changes), changes = 0))
 
       , target = d3.select('.grid-target')
             .style('height', '500px')
@@ -36,6 +44,12 @@
 
   d3.select('#stop-updates')
     .on('click', stopUpdates)
+
+  d3.select('#use-optimization').on('change', onOptimizationChange)
+
+  function onOptimizationChange() {
+    table.rowChangedKey(this.checked ? d => d.username : null)
+  }
 
   var updates
 

--- a/man/grid-performance-and-row-constancy.md
+++ b/man/grid-performance-and-row-constancy.md
@@ -1,0 +1,69 @@
+#### Grid performance and row constancy
+
+By default, the grid matches the row DOM elements to the elements in the data array by position:
+the first element in the list is rendered on the first DOM element on the page, the second to the second, etc.
+
+For example,
+if you add an element in the middle of the list and redraw the grid, all the elements from that position on will have a different element to render so all the text in the cells, etc. must change not only for that element but for all the elements after it.
+
+    Before:             After:                      DOM changes from
+
+    DOM-A → item-0      DOM-A → item-0
+    DOM-B → item-1      DOM-B → item-1
+    DOM-C → item-2      DOM-C → item-1B (new item). item-2 to new item-1B
+    DOM-D → item-3      DOM-D → item-2  ........... item-3 to item-2
+    DOM-E → item-4      DOM-E → item-3  ........... item-4 to item-3
+                        DOM-F → item-4  ........... item-4 drawn on a completely new node.
+
+But one can configure the grid to recognize the elements that it had before so that it will reuse the same DOM elements, potentially reducing the amount of changes to the DOM.
+To do this, you can configure the `rowKey` property on the grid.
+
+    var grid = createGrid().rowKey(key)
+
+    function key(d) {
+      return d.id
+    }
+
+The function passed to `rowKey` should return a unique string that identifies the row.
+The grid will use that function to determine which, if any, of the currently available row DOM elements already renders that row and will use that again for the same row.
+So, if we use `rowKey` on our example:
+
+    Before:             After:
+
+    DOM-A → item-0      DOM-A → item-0
+    DOM-B → item-1      DOM-B → item-1
+    DOM-C → item-2      DOM-F → item-1B (new item drawn on a completely new node.)
+    DOM-D → item-3      DOM-C → item-2
+    DOM-E → item-4      DOM-D → item-3
+                        DOM-E → item-4
+
+This configuration allows [object constancy](http://bost.ocks.org/mike/constancy/) for rows.
+
+Note that the row updates will still be applied to the DOM nodes even if they were the same nodes as the last time, as the data in the row fields might have changed,
+
+If you want to skip re-renders for row items you know have not changed, you can configure the grid to understand these changes.
+You can use the `rowChangedKey` property on the grid.
+(This is normally used in conjunction with `rowKey` to make sure the same rows will be drawn on the same DOM nodes)
+
+    var grid = createGrid()
+          .rowKey(_.property('id'))
+          .rowChangedKey(rowChangedKey)
+
+    function rowChangedKey(d, i) {
+      return d.id + '|' + d.bid + '|' d.ask
+    }
+
+This function should return a string which encodes what can change from a row.
+In our example, we make a string which pairs the prices with the id, into strings such as `A234|4.234|3.234`
+Whenever the grid redraws it will call this function and check if the returned value is the same as the previous result.
+If it is, it will skip the drawing of that row altogether.
+
+Note that the grid is (by default) virtualized, rows and cells are constantly being destroyed to keep the number low.
+If your row has gone out of the visible area, the next time it appears it will need to be created and process again.
+
+There is no silver bullet for performance, but you can do some tinkering with this settings to achieve the best performance for your particular data set.
+Short data sets might not benefit from virtualization and might perform better without it if in combination with these `rowKey`  and `rowChangedKey` functions.
+
+Also, sometimes it might be cheaper to redraw a new data item onto an old row with a different item than to replace the row altogether.
+As with anything performance-related, results can be counter-intuitive.
+Always use profiler and benchmark your options for determining the optimal configuration for your grid.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zambezi/grid",
-  "version": "0.11.0",
+  "version": "0.12.0-expose-row-changed-key.1",
   "description": "D3 component for drawing financial grids.",
   "keywords": [
     "d3",

--- a/src/cells.js
+++ b/src/cells.js
@@ -78,7 +78,7 @@ export function createCells() {
           )
 
         , rows = list.selectAll('.zambezi-grid-row')
-            .data(d, id)
+            .data(d, dataKey(rowKey))
 
         , rowsExit = rows.exit()
               .remove()
@@ -91,12 +91,12 @@ export function createCells() {
         , rowChanged = rows
             .merge(rowsEnter)
               .each(forward(dispatcher, 'row-update'))
+              .each(updateRow)
             .select(
               changed.key(
                 orderAndKey(rowChangedKey, visibleCellsHash)
               )
             )
-              .each(updateRow)
               .each(forward(dispatcher, 'row-changed'))
 
         , cellsUpdate = rowChanged.selectAll('.zambezi-grid-cell')

--- a/src/grid.js
+++ b/src/grid.js
@@ -62,6 +62,7 @@ export function createGrid() {
             .create()
 
       , api = rebind()
+            .from(body, 'rowChangedKey', 'rowKey')
             .from(columnDrag, 'dragColumnsByDefault', 'acceptColumnDrop')
             .from(columnSizers, 'resizeColumnsByDefault')
             .from(ensureColumns, 'columns')


### PR DESCRIPTION
## Description

The grid's `body` subcomponent supports a couple of optimization hooks that this PR exposes.

You can help the grid decide which rows do _not_ need to be redrawn by associating the DOM row with a particular datum (preserving object constancy) and then providing a `changed` function that will describe _what_ changes on a row update so that the grid can skip it if no update is needed.
 
See the proposed [man](https://github.com/zambezi/grid/blob/expose-row-changed-key-work/man/grid-performance-and-row-constancy.md) for a more detailed description.

## Motivation and Context

Grid performance is always an important topic (see, for example, #20) -- but because the grid tries to be flexible on the use cases it covers some optimizations need some help from the end user.
Telling the grid when it can skip the update of a row (or multiple rows) can help speed up the grid significantly -- cell formatters and components will be skipped, etc.

## How Was This Tested?

A rig has been created and added to the examples, as well as a "live" block here,
https://bl.ocks.org/gabrielmontagne/d9bca200af7ee7330ed82fa804551565

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
