### PR TITLE
Column template fix

### DIFF
--- a/examples/simple-column-config.html
+++ b/examples/simple-column-config.html
@@ -1,5 +1,14 @@
 <!doctype html>
-<head><meta charset="utf-8" /></head>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    .zambezi-grid-cell .icons {
+      font-family: courier-new, monospace;
+      background-color: #BBB;
+      color: white;
+    }
+  </style>
+</head>
 <body>
 <h2>grid example</h2>
 <div class="grid-target"></div>
@@ -19,6 +28,15 @@
             , { key: 'email', sortDescending: true }
             , { key: 'phone' }
             , { key: 'username' }
+            , {
+                components: [ translate, grid.updateTextIfChanged ]
+              , label: 'custom'
+              , key: 'username'
+              , template: 
+                  '<span>'
+                + '<strong class="icons"></strong> — <i class="formatted-text"></i>'
+                + '</span>'
+              }
             , { 
                 label: 'address'
               , children: [
@@ -31,6 +49,7 @@
           )
 
     , rows = _.range(1, 2000).map(faker.Helpers.createCard)
+    , icon = d3.scaleOrdinal().range('▀▄█▌▐░▒▓■')
 
   rows[10].locked = 'top'
   rows[11].locked = 'top'
@@ -41,6 +60,12 @@
       .style('height', '500px')
       .datum(rows)
       .call(table)
+
+  function translate(d) {
+    d3.select(this)
+      .select('.icons')
+        .text(d.value.split('').slice(0, 5).map(icon).join(''))
+  }
 
 </script>
 </body>

--- a/man/column-configuration.md
+++ b/man/column-configuration.md
@@ -356,3 +356,43 @@ To be able to cope with large amount of columns the grid, by default, only rende
 As you scroll horizontally, cells that come into the viewport are created and cells that move outside the viewport are destroyed.
 
 In most cases, this improves the performance of the grid by reducing the amount and processing of DOM elements on the browser.
+
+#### Per column cell template
+
+It is possible to define a cell template for specific columns by providing its HTML snipped on the `template` property of the column definition.
+
+```javascript
+grid.columns(
+      [
+        {
+          key: 'date'
+        }
+      , {
+        , key: 'template'
+        , template: '<span>SOME TEMPLATE</span>'
+        }
+      ]
+    )
+```
+
+If you provide a template it's contents won't get overwritten by the formatted text.
+You can provide a per-column component (see below) to update the contents of the created cell.
+Alternatively, you can provide a nested element with the class `formatted-text` in your template.
+The default render will write the formatted text to it.
+
+```javascript
+grid.columns(
+      [
+        {
+          key: 'date'
+        }
+      , {
+        , key: 'info'
+        , format: infoFormatter
+        , template: '<span><i class='icon-light-small-info'></i><span class='formatted-text'></span></span>'
+        }
+      ]
+    )
+```
+
+NOTE: Currently, the grid has a fixed row height.  Templates which would change the height of the row are not yet supported.

--- a/src/cells.js
+++ b/src/cells.js
@@ -28,6 +28,7 @@ export function createCells() {
         , 'row-update'
         )
       , api = rebind().from(dispatcher, 'on')
+      , appendByTemplate = {}
 
   let rowKey
     , rowChangedKey


### PR DESCRIPTION
## Description

A bug in the `cells` component was preventing the usage of templates on the column configuratin.
The fix was very simple. I've also added a usage example on the `basic-config` example, as well as to the basic config block here,

https://bl.ocks.org/gabrielmontagne/61bf45ef534990696005d88bfcabb164

## Motivation and Context

Per-column template is something that the grid _supposedly_ supported, but a few experiments highlighted a bug that caused a RE.

## How Was This Tested?

Manually on the embeded example rig, as well as on the block linked above.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
