### PR TITLE
Fix rollup watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "clean": "rimraf dist",
     "watch": "rollup -c -w",
     "test": "mocha",
+    "start": "npm run watch",
     "pretest": "npm run clean && npm run build",
     "prepublish": "npm test"
   },
@@ -33,9 +34,10 @@
     "mocha": "2.5.3",
     "normalize.css": "4.2.0",
     "rimraf": "2.5.3",
-    "rollup": "0.26.3",
+    "rollup": "0.34.10",
     "rollup-plugin-babel": "2.3.9",
-    "rollup-plugin-postcss": "0.1.1"
+    "rollup-plugin-postcss": "0.1.1",
+    "rollup-watch": "^2.5.0"
   },
   "dependencies": {
     "@zambezi/d3-utils": "^3.3.0",


### PR DESCRIPTION
Rollup --watch was not working due to the lack of a plugin. Similar to https://github.com/zambezi/grid-components/pull/9

## Description
Added `rollup-watch@2.5.0` and updated `rollup` to the latest version.

## Motivation and Context
It's annoying having to re-build everytime we change the code...

## How Was This Tested?
Manually, by running `npm start`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

