### PR TITLE
Support nested animation on grid cells

### DIFF
--- a/src/column-drag.js
+++ b/src/column-drag.js
@@ -257,13 +257,13 @@ export function createColumnDrag() {
         , clearHighlightTransition
         )
       }
-    }
-
-    function clearHighlightTransition(d, i) {
-      sheet(
-        cellSelector(d.column)
-      , { animationName: '', webkitAnimationName: '' }
-      )
+      function clearHighlightTransition(d, i) {
+        if (this !== s.node()) return
+        sheet(
+          cellSelector(d.column)
+          , { animationName: '', webkitAnimationName: '' }
+        )
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Animations in nested cell markup throw an error. This is due to the event handler for column drop transition erroneously firing.

## Motivation and Context
We're using animated components in a column component and the grid gets confused.

## How Was This Tested?
Manually on a local grid

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

