### PR TITLE
Dispatch "settings-changed" whenever column configuration has changed

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -7,6 +7,7 @@ Summary
   - [Quick start](man/quick-start.md)
   - [Column configuration](man/column-configuration.md)
   - [Row and cell events](man/row-and-cell-events.md)
+  - [Core grid events](man/core-grid-events.md)
 
 - Extending the grid
   - [Grid components](man/grid-components.md)

--- a/examples/settings-changed-events.html
+++ b/examples/settings-changed-events.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<head><meta charset="utf-8" /></head>
+<body>
+<h2>grid example</h2>
+<div class="grid-target"></div>
+<link rel="stylesheet" type="text/css" href="../node_modules/normalize.css/normalize.css">
+<script src="../node_modules/underscore/underscore.js"></script>
+<script src="../node_modules/faker/faker.js"></script>
+<script src="../node_modules/@zambezi/fun/dist/fun.js"></script>
+<script src="../node_modules/d3/build/d3.js"></script>
+<script src="../node_modules/@zambezi/d3-utils/dist/d3-utils.js"></script>
+<script src="../dist/grid.js"></script>
+<script>
+  var table = grid.createGrid()
+    , rows = _.range(1, 5000).map(_.compose(_.partial(_.pick, _, 'name', 'username', 'email'), faker.Helpers.createCard)) 
+
+  d3.select('.grid-target')
+      .style('height', '500px')
+      .datum(rows)
+      .call(table)
+      .on('settings-changed', () => console.log('settings changed'))
+
+
+</script>
+</body>

--- a/examples/settings-changed-events.html
+++ b/examples/settings-changed-events.html
@@ -12,14 +12,16 @@
 <script src="../dist/grid.js"></script>
 <script>
   var table = grid.createGrid()
+          .on(
+            'settings-changed'
+          , () => console.log('settings changed')
+          )
     , rows = _.range(1, 5000).map(_.compose(_.partial(_.pick, _, 'name', 'username', 'email'), faker.Helpers.createCard)) 
 
   d3.select('.grid-target')
       .style('height', '500px')
       .datum(rows)
       .call(table)
-      .on('settings-changed', () => console.log('settings changed'))
-
 
 </script>
 </body>

--- a/man/core-grid-events.md
+++ b/man/core-grid-events.md
@@ -1,0 +1,9 @@
+## Core grid events
+
+Besides the [row and cell lifecycle events](./row-and-cell-events.md) nd the [events related to server side filter and sorting](server-side-filter-and-sort) the grid dispatches two more core events that might be useful for synchronizing to it.
+
+* `redraw` will be dispatched every time the grid has drawn -- either by user interaction or by internal request.
+* `settings-changed` will be dispatched whenever the _settings_ of the grid have changed -- currently, these are: 
+  * a column has been dragged
+  * a column has been resized
+  * the sort on a column has changed.

--- a/src/column-drag.js
+++ b/src/column-drag.js
@@ -111,6 +111,7 @@ export function createColumnDrag() {
                   'drop.column-drag'
                 , compose(
                       highlightMovedColumnCells
+                    , () => list.dispatch('settings-changed', { bubbles: true })
                     , () => list.dispatch('redraw', { bubbles: true })
                     , dropColumnInDestination
                     , removeColumnFromOrigin

--- a/src/column-sizers.js
+++ b/src/column-sizers.js
@@ -53,6 +53,10 @@ export function createColumnSizers() {
                               // up again soon.
               .remove()       // ... remove if they haven't.
         , sizers = sizersUpdate.merge(sizersEnter)
+        , dispatchSettingsChanged = debounce(
+            () => target.dispatch('settings-changed', { bubbles: true })
+          , 300
+          )
 
     sizers.on('mousedown.column-sizers', onSizerMousedown)
     sizers.filter('.is-recycled')
@@ -101,6 +105,7 @@ export function createColumnSizers() {
 
       column.width = newWidth
       target.dispatch('redraw')
+      dispatchSettingsChanged()
 
       function findCandidateFreeWidth() {
 

--- a/src/grid.js
+++ b/src/grid.js
@@ -37,7 +37,7 @@ export function createGrid() {
       , resize = createResize()
       , unpackNestedRows = createUnpackNestedRows()
       , columnSizers = createColumnSizers()
-      , dispatchDraw = createDispatch('draw')
+      , coreEvents = createDispatch('draw', 'settings-changed')
       , groupRows = createGroupRows()
       , body = createBody()
       , runExternalComponents = createRunExternalComponents()
@@ -47,7 +47,7 @@ export function createGrid() {
       , shareDispatcher = createShareDispatcher()
       , autodirty = createAutoDirty()
       , redispatcher = redispatch()
-            .from(dispatchDraw, 'draw')
+            .from(coreEvents, 'draw', 'settings-changed')
             .from(sortRowHeaders, 'sort-changed')
             .from(
               body
@@ -80,7 +80,8 @@ export function createGrid() {
             .from(unpackNestedRows, 'showRowWhenCollapsed')
 
       , grid = compose(
-          call(() => dispatchDraw.call('draw'))
+          call(() => coreEvents.call('draw'))
+        , call(s => s.on('settings-changed', () => coreEvents.call('settings-changed')))
         , call(runExternalComponents)
         , call(createScrollers())
         , call(sortRowHeaders)

--- a/src/sort-row-headers.js
+++ b/src/sort-row-headers.js
@@ -58,6 +58,7 @@ export function createSortRowHeaders() {
 
       target
           .dispatch('data-dirty')
+          .dispatch('settings-changed')
           .dispatch('redraw')
 
       function clearColumnSort(d, i) {


### PR DESCRIPTION
## Description

With this PR, the grid dispatches `settings-changed` whenever the settings change.
For now, these "settings" are column configuration changes: column order, column sorting, and column width.

But any component can dispatch the event itself through the DOM if needed.

## Motivation and Context

The purpose of this change is to allow a central handler for serializing whatever settings are needed (per application) for persistence purposes. 

## How Was This Tested?

This has been tested on the provided `settings-changed-events` rig in the examples folder.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
