### PR TITLE
Datasets; part of the IE10 compatibility viacrucis

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zambezi/grid",
-  "version": "0.14.0",
+  "version": "0.14.1-dataset-ie-support.1",
   "description": "D3 component for drawing financial grids.",
   "keywords": [
     "d3",

--- a/src/cells.js
+++ b/src/cells.js
@@ -1,4 +1,5 @@
 import { appendFromTemplate, selectionChanged, rebind, forward } from '@zambezi/d3-utils'
+import { dataset } from './dataset'
 import { dispatch as createDispatch } from 'd3-dispatch'
 import { property, batch } from '@zambezi/fun'
 import { select } from 'd3-selection'
@@ -14,7 +15,6 @@ const appendDefaultCell = appendFromTemplate(
     , id = property('id')
     , isFirst = property('isFirst')
     , isLast = property('isLast')
-    , rowIndexMatch = /(\bgrid-row-index-\d+\b|$)/
 
 export function createCells() {
 
@@ -93,7 +93,7 @@ export function createCells() {
             .merge(rowsEnter)
               .each(forward(dispatcher, 'row-update'))
               .each(updateRow)
-              .attr('data-grid-row-index', d => d.index)
+              .call(dataset, 'gridRowIndex', d => d.index)
             .select(
               changed.key(
                 orderAndKey(rowChangedKey, visibleCellsHash)
@@ -197,3 +197,4 @@ function dataKey(rowKey) {
 function firstAndLast(d) {
   return d.isFirst + '★' + d.isLast
 }
+

--- a/src/cells.js
+++ b/src/cells.js
@@ -93,6 +93,7 @@ export function createCells() {
             .merge(rowsEnter)
               .each(forward(dispatcher, 'row-update'))
               .each(updateRow)
+              .attr('data-grid-row-index', d => d.index)
             .select(
               changed.key(
                 orderAndKey(rowChangedKey, visibleCellsHash)
@@ -156,7 +157,6 @@ export function createCells() {
     const index = d.index
         , selector = `#${ gridId } [data-grid-row-index="${index}"]`
 
-    this.dataset.gridRowIndex = index
     sheet(selector, { top: top(d) })
   }
 }

--- a/src/dataset.js
+++ b/src/dataset.js
@@ -1,0 +1,19 @@
+import { memoize } from 'underscore'
+import { isIE } from './is-ie'
+import { functor } from '@zambezi/fun'
+
+const upperCasePattern = /[A-Z]/g
+const toDataAttribute = memoize(toDataAttributeFromPattern)
+
+export function dataset(s, key, value) {
+  const v = functor(value)
+  if (isIE) s.attr(toDataAttribute(key), value)
+  else s.each(setValue)
+  function setValue() {
+    this.dataset[key] = v.apply(this, arguments)
+  }
+}
+
+function toDataAttributeFromPattern(key) {
+  return 'data-' + key.replace(upperCasePattern, s => `-${s.toLowerCase()}`)
+}

--- a/src/ensure-id.js
+++ b/src/ensure-id.js
@@ -7,6 +7,6 @@ export function ensureId(d, i) {
 
   target.attr(
     'id'
-  , this.dataset.componentId || uniqueId('gen-grid-')
+  , target.attr('data-component-id') || uniqueId('gen-grid-')
   )
 }

--- a/src/ensure-id.js
+++ b/src/ensure-id.js
@@ -4,9 +4,10 @@ import { uniqueId } from 'underscore'
 export function ensureId(d, i) {
   const target = select(this)
   if (target.attr('id')) return
-
   target.attr(
     'id'
-  , target.attr('data-component-id') || uniqueId('gen-grid-')
+  ,     (this.dataset && this.dataset.componentId)
+    ||  target.attr('data-component-id') 
+    ||  uniqueId('gen-grid-')
   )
 }

--- a/src/unpack-nested-rows.js
+++ b/src/unpack-nested-rows.js
@@ -1,7 +1,8 @@
+import { dataset } from './dataset'
+import { isFunction } from 'underscore'
 import { property } from '@zambezi/fun'
 import { select } from 'd3-selection'
 import { selectionChanged } from '@zambezi/d3-utils'
-import { isFunction } from 'underscore'
 import { wrap } from './wrap-row'
 
 const rowNestedLevelChanged = selectionChanged()
@@ -45,7 +46,7 @@ export function createUnpackNestedRows() {
   function setRowNestLevel(d, i) {
     select(this)
       .select(rowNestedLevelChanged)
-      .attr('data-nest-level', d.row.nestLevel)
+      .call(dataset, 'nestLevel', d.row.nestLevel)
   }
 
   function unpackRows(d) {

--- a/src/unpack-nested-rows.js
+++ b/src/unpack-nested-rows.js
@@ -45,7 +45,7 @@ export function createUnpackNestedRows() {
   function setRowNestLevel(d, i) {
     select(this)
       .select(rowNestedLevelChanged)
-      .each(() => this.dataset.nestLevel = d.row.nestLevel)
+      .attr('data-nest-level', d.row.nestLevel)
   }
 
   function unpackRows(d) {


### PR DESCRIPTION
## Description

Makes the grid revert to `data-whatever-attribute` when `node.dataset` is not available.

## Motivation and Context

The grid doesn't pretend to run everywhere -- it's the responsibility of the app in which this is to be embedded to cater for transpilations, perspirations and polyfillings which, we'd guess, are needed not only for this component.
 
But while most of the modern JS usage can be fixed at build time using something like `babel-polyfill`, some things remain run time pastimes. 

At _The Office_:tm: we had two problems that forced us to lay hands on our pre-compiled code (actually only one main problem, IE10 support, but... )

1. D3v4 dispatch of native dom events in IE -- we had to add a good old polyfill to our app.
2. The `dataset` incompatibility, which cannot really be addressed "once and for all", but needed to be, sad but true, embedded on the grid.

Hence this PR.

Smarter people might find a nicer solution.  Please?
Anyways, for now, if you don't mind....

## How Was This Tested?

To properly test this we created a (still offline) fully webpacked build with polyfills, etc. to run this on IE.
Nothing we can easily upload to a block

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
